### PR TITLE
Configure MyDataRestConfig to expose ids via REST API

### DIFF
--- a/src/main/java/com/sankdev/fluffybest/config/MyDataRestConfig.java
+++ b/src/main/java/com/sankdev/fluffybest/config/MyDataRestConfig.java
@@ -4,6 +4,12 @@ import com.sankdev.fluffybest.entity.Language;
 import com.sankdev.fluffybest.entity.Product;
 import com.sankdev.fluffybest.entity.ProductCategory;
 import com.sankdev.fluffybest.entity.location.Country;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.EntityType;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
@@ -13,6 +19,12 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 @Configuration
 public class MyDataRestConfig implements RepositoryRestConfigurer {
 
+  private EntityManager entityManager;
+
+  @Autowired
+  public MyDataRestConfig(EntityManager theEntityManager) {
+    entityManager = theEntityManager;
+  }
 
   @Override
   public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config,
@@ -47,6 +59,29 @@ public class MyDataRestConfig implements RepositoryRestConfigurer {
         .withItemExposure((metdata, httpMethods) -> httpMethods.disable(theUnsupportedActions))
         .withCollectionExposure(
             ((metdata, httpMethods) -> httpMethods.disable(theUnsupportedActions)));
+
+    // call an internal helper method
+    exposeIds(config);
+  }
+
+  private void exposeIds(RepositoryRestConfiguration config) {
+
+    // expose entity ids
+
+    // - get a list of all entity classes from the entity manager
+    Set<EntityType<?>> entities = entityManager.getMetamodel().getEntities();
+
+    // - create an array of the entity types
+    List<Class> entityClasses = new ArrayList<>();
+
+    // - get the entity types for the entities
+    for (EntityType tempEntityType : entities) {
+      entityClasses.add(tempEntityType.getJavaType());
+    }
+
+    // - expose the entity ids for the array of entity/domain types
+    Class[] domainTypes = entityClasses.toArray(new Class[0]);
+    config.exposeIdsFor(domainTypes);
 
   }
 }


### PR DESCRIPTION
We are gonna need id passed via REST API from Spring Boot Backend in order to:
- dynamically organize links in menus for Frontend
- create master/detail view for search by product id, etc.